### PR TITLE
avoid plugin classLoader reload classes by app loader

### DIFF
--- a/bifromq-plugin/bifromq-plugin-manager/src/main/java/com/baidu/bifromq/plugin/manager/BifroMQJarPluginLoader.java
+++ b/bifromq-plugin/bifromq-plugin-manager/src/main/java/com/baidu/bifromq/plugin/manager/BifroMQJarPluginLoader.java
@@ -14,10 +14,8 @@
 package com.baidu.bifromq.plugin.manager;
 
 import java.nio.file.Path;
-import org.pf4j.JarPluginLoader;
-import org.pf4j.PluginClassLoader;
-import org.pf4j.PluginDescriptor;
-import org.pf4j.PluginManager;
+
+import org.pf4j.*;
 
 class BifroMQJarPluginLoader extends JarPluginLoader {
     public BifroMQJarPluginLoader(PluginManager pluginManager) {
@@ -27,7 +25,7 @@ class BifroMQJarPluginLoader extends JarPluginLoader {
     @Override
     public ClassLoader loadPlugin(Path pluginPath, PluginDescriptor pluginDescriptor) {
         PluginClassLoader pluginClassLoader = new BifroMQPluginClassLoader(pluginManager,
-            pluginDescriptor, getClass().getClassLoader());
+            pluginDescriptor, getClass().getClassLoader(), ClassLoadingStrategy.APD);
         pluginClassLoader.addFile(pluginPath.toFile());
 
         return pluginClassLoader;

--- a/bifromq-plugin/bifromq-plugin-manager/src/main/java/com/baidu/bifromq/plugin/manager/BifroMQJarPluginLoader.java
+++ b/bifromq-plugin/bifromq-plugin-manager/src/main/java/com/baidu/bifromq/plugin/manager/BifroMQJarPluginLoader.java
@@ -14,6 +14,7 @@
 package com.baidu.bifromq.plugin.manager;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 
 import org.pf4j.*;
 
@@ -25,7 +26,9 @@ class BifroMQJarPluginLoader extends JarPluginLoader {
     @Override
     public ClassLoader loadPlugin(Path pluginPath, PluginDescriptor pluginDescriptor) {
         PluginClassLoader pluginClassLoader = new BifroMQPluginClassLoader(pluginManager,
-            pluginDescriptor, getClass().getClassLoader(), ClassLoadingStrategy.APD);
+            pluginDescriptor, getClass().getClassLoader(),
+                new ClassLoadingStrategy(Arrays.asList(ClassLoadingStrategy.Source.PLUGIN,
+                        ClassLoadingStrategy.Source.DEPENDENCIES)));
         pluginClassLoader.addFile(pluginPath.toFile());
 
         return pluginClassLoader;

--- a/bifromq-plugin/bifromq-plugin-manager/src/main/java/com/baidu/bifromq/plugin/manager/ProvidedPackages.java
+++ b/bifromq-plugin/bifromq-plugin-manager/src/main/java/com/baidu/bifromq/plugin/manager/ProvidedPackages.java
@@ -22,6 +22,7 @@ public class ProvidedPackages {
     static {
         PACKAGES.add("com.baidu.bifromq.");
         PACKAGES.add("io.micrometer.core");
+        PACKAGES.add("com.google.protobuf");
         PACKAGES.add("org.slf4j.");
     }
 


### PR DESCRIPTION
if plugin classLoader workes first, some classes like ByteString will be reloaded and then cause constraint violation