### PR TITLE
1. switch contextClassLoader for extension instantiation

### DIFF
--- a/bifromq-plugin/bifromq-plugin-manager/src/main/java/com/baidu/bifromq/plugin/manager/BifroMQPluginManager.java
+++ b/bifromq-plugin/bifromq-plugin-manager/src/main/java/com/baidu/bifromq/plugin/manager/BifroMQPluginManager.java
@@ -13,12 +13,14 @@
 
 package com.baidu.bifromq.plugin.manager;
 
+import lombok.extern.slf4j.Slf4j;
 import org.pf4j.CompoundPluginLoader;
 import org.pf4j.DefaultPluginManager;
 import org.pf4j.ExtensionFactory;
 import org.pf4j.PluginLoader;
 import org.pf4j.PluginRuntimeException;
 
+@Slf4j
 public class BifroMQPluginManager extends DefaultPluginManager {
     @Override
     protected PluginLoader createPluginLoader() {
@@ -35,9 +37,11 @@ public class BifroMQPluginManager extends DefaultPluginManager {
             public <T> T create(Class<T> extensionClass) {
                 try {
                     ClassLoader originalLoader = Thread.currentThread().getContextClassLoader();
-                    Thread.currentThread().setContextClassLoader(extensionClass.getClassLoader());
+                    ClassLoader targetLoader = extensionClass.getClassLoader();
+                    Thread.currentThread().setContextClassLoader(targetLoader);
                     T instance = extensionClass.newInstance();
                     Thread.currentThread().setContextClassLoader(originalLoader);
+                    log.debug("switch from target loader: {} to default loader: {}", targetLoader, originalLoader);
                     return instance;
                 } catch (Exception e) {
                     throw new PluginRuntimeException(e);

--- a/bifromq-plugin/bifromq-plugin-manager/src/main/java/com/baidu/bifromq/plugin/manager/BifroMQPluginManager.java
+++ b/bifromq-plugin/bifromq-plugin-manager/src/main/java/com/baidu/bifromq/plugin/manager/BifroMQPluginManager.java
@@ -15,7 +15,9 @@ package com.baidu.bifromq.plugin.manager;
 
 import org.pf4j.CompoundPluginLoader;
 import org.pf4j.DefaultPluginManager;
+import org.pf4j.ExtensionFactory;
 import org.pf4j.PluginLoader;
+import org.pf4j.PluginRuntimeException;
 
 public class BifroMQPluginManager extends DefaultPluginManager {
     @Override
@@ -24,5 +26,23 @@ public class BifroMQPluginManager extends DefaultPluginManager {
             .add(new BifroMQDevelopmentPluginLoader(this), this::isDevelopment)
             .add(new BifroMQJarPluginLoader(this), this::isNotDevelopment)
             .add(new BifroMQDefaultPluginLoader(this), this::isNotDevelopment);
+    }
+
+    @Override
+    protected ExtensionFactory createExtensionFactory() {
+        return new ExtensionFactory() {
+            @Override
+            public <T> T create(Class<T> extensionClass) {
+                try {
+                    ClassLoader originalLoader = Thread.currentThread().getContextClassLoader();
+                    Thread.currentThread().setContextClassLoader(extensionClass.getClassLoader());
+                    T instance = extensionClass.newInstance();
+                    Thread.currentThread().setContextClassLoader(originalLoader);
+                    return instance;
+                } catch (Exception e) {
+                    throw new PluginRuntimeException(e);
+                }
+            }
+        };
     }
 }

--- a/bifromq-plugin/bifromq-plugin-manager/src/main/java/com/baidu/bifromq/plugin/manager/BifroMQPluginManager.java
+++ b/bifromq-plugin/bifromq-plugin-manager/src/main/java/com/baidu/bifromq/plugin/manager/BifroMQPluginManager.java
@@ -35,15 +35,16 @@ public class BifroMQPluginManager extends DefaultPluginManager {
         return new ExtensionFactory() {
             @Override
             public <T> T create(Class<T> extensionClass) {
+                log.debug("Create instance for extension '{}'", extensionClass.getName());
+                ClassLoader originalLoader = Thread.currentThread().getContextClassLoader();
                 try {
-                    ClassLoader originalLoader = Thread.currentThread().getContextClassLoader();
                     ClassLoader targetLoader = extensionClass.getClassLoader();
                     Thread.currentThread().setContextClassLoader(targetLoader);
                     T instance = extensionClass.newInstance();
                     Thread.currentThread().setContextClassLoader(originalLoader);
-                    log.debug("switch from target loader: {} to default loader: {}", targetLoader, originalLoader);
                     return instance;
                 } catch (Exception e) {
+                    Thread.currentThread().setContextClassLoader(originalLoader);
                     throw new PluginRuntimeException(e);
                 }
             }


### PR DESCRIPTION
For classes instantiation that rely on ContextClassLoader, if not, one may encounter class not found exception. 