### PR TITLE
Fix that server side FetchState did not be removed when mqtt sesion close

### DIFF
--- a/bifromq-inbox/bifromq-inbox-client/pom.xml
+++ b/bifromq-inbox/bifromq-inbox-client/pom.xml
@@ -41,5 +41,14 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <!--For Testing-->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/bifromq-inbox/bifromq-inbox-client/src/main/java/com/baidu/bifromq/inbox/client/InboxClient.java
+++ b/bifromq-inbox/bifromq-inbox-client/src/main/java/com/baidu/bifromq/inbox/client/InboxClient.java
@@ -14,19 +14,14 @@
 package com.baidu.bifromq.inbox.client;
 
 import static com.baidu.bifromq.inbox.util.DelivererKeyUtil.getDelivererKey;
-import static com.baidu.bifromq.inbox.util.PipelineUtil.PIPELINE_ATTR_KEY_ID;
-import static java.util.Collections.singletonMap;
 
 import com.baidu.bifromq.baserpc.IRPCClient;
-import com.baidu.bifromq.baserpc.IRPCClient.IMessageStream;
 import com.baidu.bifromq.inbox.RPCBluePrint;
 import com.baidu.bifromq.inbox.rpc.proto.CreateInboxReply;
 import com.baidu.bifromq.inbox.rpc.proto.CreateInboxRequest;
 import com.baidu.bifromq.inbox.rpc.proto.DeleteInboxReply;
 import com.baidu.bifromq.inbox.rpc.proto.DeleteInboxRequest;
 import com.baidu.bifromq.inbox.rpc.proto.HasInboxRequest;
-import com.baidu.bifromq.inbox.rpc.proto.InboxFetchHint;
-import com.baidu.bifromq.inbox.rpc.proto.InboxFetched;
 import com.baidu.bifromq.inbox.rpc.proto.InboxServiceGrpc;
 import com.baidu.bifromq.inbox.rpc.proto.SubReply;
 import com.baidu.bifromq.inbox.rpc.proto.SubRequest;
@@ -41,16 +36,12 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.reactivex.rxjava3.core.Observable;
-import java.lang.ref.Cleaner;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 final class InboxClient implements IInboxClient {
-    private static final Cleaner CLEANER = Cleaner.create();
-
     private final AtomicBoolean hasStopped = new AtomicBoolean();
     private final IRPCClient rpcClient;
     private final LoadingCache<FetchPipelineKey, InboxFetchPipeline> fetchPipelineCache;
@@ -66,15 +57,7 @@ final class InboxClient implements IInboxClient {
         fetchPipelineCache = Caffeine.newBuilder()
             .weakValues()
             .executor(MoreExecutors.directExecutor())
-            .build(key -> {
-                IMessageStream<InboxFetched, InboxFetchHint> messageStream =
-                    rpcClient.createMessageStream(key.tenantId, null, key.delivererKey,
-                        singletonMap(PIPELINE_ATTR_KEY_ID, UUID.randomUUID().toString()),
-                        InboxServiceGrpc.getFetchInboxMethod());
-                InboxFetchPipeline inboxFetchPipeline = new InboxFetchPipeline(key.tenantId, messageStream, rpcClient);
-                CLEANER.register(inboxFetchPipeline, new PipelineCloseAction(messageStream));
-                return inboxFetchPipeline;
-            });
+            .build(key -> new InboxFetchPipeline(key.tenantId, key.delivererKey, rpcClient));
     }
 
     @Override
@@ -194,18 +177,5 @@ final class InboxClient implements IInboxClient {
     }
 
     private record FetchPipelineKey(String tenantId, String delivererKey) {
-    }
-
-    private static class PipelineCloseAction implements Runnable {
-        private final IRPCClient.IMessageStream<InboxFetched, InboxFetchHint> messageStream;
-
-        private PipelineCloseAction(IRPCClient.IMessageStream<InboxFetched, InboxFetchHint> messageStream) {
-            this.messageStream = messageStream;
-        }
-
-        @Override
-        public void run() {
-            messageStream.close();
-        }
     }
 }

--- a/bifromq-inbox/bifromq-inbox-client/src/main/java/com/baidu/bifromq/inbox/client/InboxReader.java
+++ b/bifromq-inbox/bifromq-inbox-client/src/main/java/com/baidu/bifromq/inbox/client/InboxReader.java
@@ -81,6 +81,8 @@ class InboxReader implements IInboxClient.IInboxReader {
 
     @Override
     public void close() {
+        // tell server side to remove FetchState
+        hint(-1);
         ppln.stopFetch(inboxId);
     }
 }

--- a/bifromq-inbox/bifromq-inbox-client/src/test/java/com.baidu.bifromq.inbox.client/InboxReaderTest.java
+++ b/bifromq-inbox/bifromq-inbox-client/src/test/java/com.baidu.bifromq.inbox.client/InboxReaderTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2023. Baidu, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.baidu.bifromq.inbox.client;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.baidu.bifromq.baserpc.IRPCClient;
+import com.baidu.bifromq.inbox.rpc.proto.CommitReply;
+import com.baidu.bifromq.inbox.rpc.proto.CommitRequest;
+import com.baidu.bifromq.inbox.rpc.proto.InboxFetchHint;
+import com.baidu.bifromq.inbox.rpc.proto.InboxFetched;
+import com.baidu.bifromq.inbox.rpc.proto.InboxServiceGrpc;
+import com.baidu.bifromq.inbox.storage.proto.Fetched;
+import com.baidu.bifromq.inbox.storage.proto.Fetched.Result;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.subjects.PublishSubject;
+import io.reactivex.rxjava3.subjects.Subject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import lombok.SneakyThrows;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class InboxReaderTest {
+    private AutoCloseable closeable;
+    @Mock
+    private Consumer<Fetched> onFetched;
+    @Mock
+    private IRPCClient rpcClient;
+    @Mock
+    private IRPCClient.IMessageStream<InboxFetched, InboxFetchHint> messageStream;
+    private InboxFetchPipeline fetchPipeline;
+    private final String tenantId = "tenantId";
+    private final String delivererKey = "delivererKey";
+    private final String inboxId = "inboxId";
+    private final AtomicReference<Subject<InboxFetched>> fetchSubject = new AtomicReference<>();
+
+    @BeforeMethod
+    public void setup() {
+        closeable = MockitoAnnotations.openMocks(this);
+        when(rpcClient.createMessageStream(eq(tenantId), any(), eq(delivererKey), anyMap(),
+            eq(InboxServiceGrpc.getFetchInboxMethod()))).thenReturn(messageStream);
+        when(messageStream.msg()).thenAnswer((Answer<Observable<InboxFetched>>) invocationOnMock -> {
+            fetchSubject.set(PublishSubject.create());
+            return fetchSubject.get();
+        });
+        fetchPipeline = new InboxFetchPipeline(tenantId, delivererKey, rpcClient);
+    }
+
+    @AfterMethod
+    @SneakyThrows
+    public void teardown() {
+        closeable.close();
+    }
+
+    @Test
+    public void fetch() {
+        when(rpcClient.invoke(eq(tenantId), any(), any(CommitRequest.class), eq(InboxServiceGrpc.getCommitMethod())))
+            .thenReturn(CompletableFuture.completedFuture(CommitReply.newBuilder().build()));
+        Fetched fetched = Fetched.newBuilder()
+            .setResult(Result.OK)
+            .addQos0Seq(1L)
+            .build();
+        InboxFetched inboxFetched = InboxFetched.newBuilder().setInboxId(inboxId).setFetched(fetched).build();
+        InboxReader inboxReader = new InboxReader(inboxId, fetchPipeline);
+        inboxReader.fetch(onFetched);
+        fetchSubject.get().onNext(inboxFetched);
+        verify(onFetched, times(1)).accept(fetched);
+        verify(rpcClient, times(1)).invoke(eq(tenantId), any(), any(CommitRequest.class),
+            eq(InboxServiceGrpc.getCommitMethod()));
+    }
+
+    @Test
+    public void reFetchAfterError() {
+        Fetched fetchedError = Fetched.newBuilder().setResult(Result.ERROR).build();
+        InboxReader inboxReader = new InboxReader(inboxId, fetchPipeline);
+        inboxReader.fetch(onFetched);
+        fetchSubject.get().onError(new RuntimeException("Test Exception"));
+        verify(onFetched, times(1)).accept(fetchedError);
+        verify(messageStream, times(2)).msg();
+    }
+
+    @Test
+    public void reFetchAfterComplete() {
+        Fetched fetchedError = Fetched.newBuilder().setResult(Result.ERROR).build();
+        InboxReader inboxReader = new InboxReader(inboxId, fetchPipeline);
+        inboxReader.fetch(onFetched);
+        fetchSubject.get().onComplete();
+        verify(onFetched, times(1)).accept(fetchedError);
+        verify(messageStream, times(2)).msg();
+    }
+
+    @Test
+    public void registerGC() throws InterruptedException {
+        InboxReader inboxReader = new InboxReader(inboxId, new InboxFetchPipeline(tenantId, delivererKey, rpcClient));
+        inboxReader.close();
+        inboxReader = null;
+        System.gc();
+        Thread.sleep(10);
+        await().until(() -> {
+            verify(messageStream, times(1)).close();
+            return true;
+        });
+    }
+
+    @Test
+    public void fetchPipelineClose() throws InterruptedException {
+        InboxFetchPipeline inboxFetchPipeline = new InboxFetchPipeline(tenantId, delivererKey, rpcClient);
+        inboxFetchPipeline.close();
+        Thread.sleep(10);
+        await().until(() -> {
+            verify(messageStream, times(1)).close();
+            return true;
+        });
+    }
+}

--- a/bifromq-inbox/bifromq-inbox-rpc-definition/src/main/proto/inboxservice/InboxService.proto
+++ b/bifromq-inbox/bifromq-inbox-rpc-definition/src/main/proto/inboxservice/InboxService.proto
@@ -140,14 +140,11 @@ message SendReply {
   repeated SendResult result = 2;
 }
 
-message FetchHint {
-  uint32 capacity = 1;
-}
 
 message InboxFetchHint {
   uint64 incarnation = 1;
   string inboxId = 2;
-  uint32 capacity = 3;
+  int32 capacity = 3;
   uint64 lastFetchQoS0Seq = 4;
   uint64 lastFetchQoS1Seq = 5;
   uint64 lastFetchQoS2Seq = 6;

--- a/bifromq-session-dict/bifromq-session-dict-client/pom.xml
+++ b/bifromq-session-dict/bifromq-session-dict-client/pom.xml
@@ -41,5 +41,9 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/bifromq-session-dict/bifromq-session-dict-client/src/main/java/com/baidu/bifromq/sessiondict/client/SessionRegPipeline.java
+++ b/bifromq-session-dict/bifromq-session-dict-client/src/main/java/com/baidu/bifromq/sessiondict/client/SessionRegPipeline.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023. Baidu, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.baidu.bifromq.sessiondict.client;
+
+import com.baidu.bifromq.baserpc.IRPCClient;
+import com.baidu.bifromq.sessiondict.rpc.proto.Quit;
+import com.baidu.bifromq.sessiondict.rpc.proto.Session;
+import com.baidu.bifromq.type.ClientInfo;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.observers.DisposableObserver;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SessionRegPipeline {
+
+    private final IRPCClient.IMessageStream<Quit, Session> messageStream;
+    private final Map<ClientInfo, Consumer<Quit>> sessions;
+
+    public SessionRegPipeline(IRPCClient.IMessageStream<Quit, Session> messageStream) {
+        this.messageStream = messageStream;
+        this.sessions = new ConcurrentHashMap<>();
+        new QuitObserver(messageStream, sessions).initObserve();
+    }
+
+    public void sendRegInfo(ClientInfo owner, boolean keep) {
+        messageStream.ack(Session.newBuilder()
+            .setReqId(System.nanoTime())
+            .setOwner(owner)
+            .setKeep(keep)
+            .build());
+    }
+
+    public void reg(ClientInfo owner, Consumer<Quit> kickConsumer) {
+        sessions.put(owner, kickConsumer);
+    }
+
+    public void unReg(ClientInfo owner) {
+        sessions.remove(owner);
+    }
+
+    private static class QuitObserver {
+        private final IRPCClient.IMessageStream<Quit, Session> stream;
+        private final Map<ClientInfo, Consumer<Quit>> sessions;
+
+        public QuitObserver(IRPCClient.IMessageStream<Quit, Session> stream,
+                            Map<ClientInfo, Consumer<Quit>> sessions) {
+            this.stream = stream;
+            this.sessions = sessions;
+        }
+
+        private void initObserve() {
+            if (!stream.isClosed()) {
+                for (ClientInfo owner : sessions.keySet()) {
+                    stream.ack(Session.newBuilder()
+                        .setReqId(System.nanoTime())
+                        .setOwner(owner)
+                        .setKeep(true)
+                        .build());
+                }
+                stream.msg()
+                    .subscribeWith(new DisposableObserver<Quit>() {
+                        @Override
+                        public void onNext(@NonNull Quit quit) {
+                            sessions.computeIfPresent(quit.getOwner(), (k, v) -> {
+                                v.accept(quit);
+                                return v;
+                            });
+                        }
+
+                        @Override
+                        public void onError(@NonNull Throwable e) {
+                            dispose();
+                            initObserve();
+                        }
+
+                        @Override
+                        public void onComplete() {
+                            dispose();
+                            initObserve();
+                        }
+                    });
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. Fix that server side FetchState did not be removed when mqtt sesion close.

2. Fix that client side Pipeline in weakValues Cache could not be gc.