### PR TITLE
print jvm params and initial settings when the server starts

### DIFF
--- a/build/build-bifromq-starters/src/main/java/com/baidu/bifromq/starter/StandaloneStarter.java
+++ b/build/build-bifromq-starters/src/main/java/com/baidu/bifromq/starter/StandaloneStarter.java
@@ -612,13 +612,13 @@ public class StandaloneStarter extends BaseEngineStarter<StandaloneConfig> {
         log.info("Settings, which can be modified at runtime, allowing for dynamic adjustment of BifroMQ's " +
                 "service behavior per tenant. See https://bifromq.io/docs/plugin/setting_provider/");
         log.info("Following is the initial value of each setting: ");
-        for (int i = 0; i < Setting.values().length; ++i) {
-            log.info("Setting: {}={}", Setting.values()[i].name(), Setting.values()[i].current(""));
+        for (Setting setting : Setting.values()) {
+            log.info("Setting: {}={}", setting.name(), setting.current(""));
         }
 
         log.info("BifroMQ system properties: ");
-        for (int i = 0; i < BifroMQSysProp.values().length; ++i) {
-            log.info("BifroMQSysProp: {}={}", BifroMQSysProp.values()[i].name(), BifroMQSysProp.values()[i].get());
+        for (BifroMQSysProp prop : BifroMQSysProp.values()) {
+            log.info("BifroMQSysProp: {}={}", prop.propKey, prop.get());
         }
 
         log.info("Consolidated Config: \n{}", ConfigUtil.serialize(config));

--- a/build/build-bifromq-starters/src/main/java/com/baidu/bifromq/starter/StandaloneStarter.java
+++ b/build/build-bifromq-starters/src/main/java/com/baidu/bifromq/starter/StandaloneStarter.java
@@ -57,6 +57,7 @@ import com.baidu.bifromq.starter.config.standalone.model.StateStoreConfig;
 import com.baidu.bifromq.starter.config.standalone.model.apiserver.APIServerConfig;
 import com.baidu.bifromq.starter.config.standalone.model.mqttserver.MQTTServerConfig;
 import com.baidu.bifromq.starter.utils.ConfigUtil;
+import com.baidu.bifromq.sysprops.BifroMQSysProp;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -122,7 +123,7 @@ public class StandaloneStarter extends BaseEngineStarter<StandaloneConfig> {
     @Override
     protected void init(StandaloneConfig config) {
         StandaloneConfigConsolidator.consolidate(config);
-        printConfigures(config);
+        printConfigs(config);
 
         if (!Strings.isNullOrEmpty(config.getClusterConfig().getEnv())) {
             Metrics.globalRegistry.config()
@@ -604,7 +605,7 @@ public class StandaloneStarter extends BaseEngineStarter<StandaloneConfig> {
             inboxClient, sessionDictClient, retainClient, settingProviderMgr);
     }
 
-    private void printConfigures(StandaloneConfig config) {
+    private void printConfigs(StandaloneConfig config) {
         List<String> arguments = ManagementFactory.getRuntimeMXBean().getInputArguments();
         log.info("JVM arguments: \n  {}", String.join("\n  ", arguments));
 
@@ -613,6 +614,11 @@ public class StandaloneStarter extends BaseEngineStarter<StandaloneConfig> {
         log.info("Following is the initial value of each setting: ");
         for (int i = 0; i < Setting.values().length; ++i) {
             log.info("Setting: {}={}", Setting.values()[i].name(), Setting.values()[i].current(""));
+        }
+
+        log.info("BifroMQ system properties: ");
+        for (int i = 0; i < BifroMQSysProp.values().length; ++i) {
+            log.info("BifroMQSysProp: {}={}", BifroMQSysProp.values()[i].name(), BifroMQSysProp.values()[i].get());
         }
 
         log.info("Consolidated Config: \n{}", ConfigUtil.serialize(config));


### PR DESCRIPTION
The logs like:

15:21:46.890 [main] INFO  c.b.b.starter.StandaloneStarter - JVM arguments: 
-Xms1045m
-Xmx4096m
-Xlog:gc:file=/usr/share/bifromq-standalone/bin/../logs/gc-%t.log:time,tid,tags:filecount=5,filesize=50m
-DLOG_DIR=/usr/share/bifromq-standalone/bin/../logs
-DCONF_DIR=/usr/share/bifromq-standalone/bin/../conf
-DDATA_DIR=/usr/share/bifromq-standalone/bin/../data
-DBIND_ADDR=127.0.0.1
-Dpf4j.pluginsDir=/usr/share/bifromq-standalone/bin/../plugins
-Dfile.encoding=UTF-8
15:21:46.890 [main] INFO  c.b.b.starter.StandaloneStarter - Settings, which can be modified at runtime, allowing for dynamic adjustment of BifroMQ's service behavior per tenant. See https://bifromq.io/docs/plugin/setting_provider/
15:21:46.890 [main] INFO  c.b.b.starter.StandaloneStarter - Following is the initial value of each setting: 
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: DebugModeEnabled=false
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: MaxTopicLevelLength=40
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: MaxTopicLevels=16
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: MaxTopicLength=255
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: MaxSharedGroupMembers=200
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: MaxTopicFiltersPerInbox=100
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: MsgPubPerSec=200
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: InBoundBandWidth=524288
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: OutBoundBandWidth=524288
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: ForceTransient=false
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: ByPassPermCheckError=true
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: MaxUserPayloadBytes=262144
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: MaxTopicFiltersPerSub=10
15:21:46.913 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: OfflineExpireTimeSeconds=86400
15:21:46.914 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: OfflineQueueSize=1000
15:21:46.914 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: OfflineOverflowDropOldest=false
15:21:46.914 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: RetainedTopicLimit=10
15:21:46.914 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: RetainMessageMatchLimit=10
15:21:46.914 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: RetainEnabled=true
15:21:46.914 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: DistReservedUnitInterval=4294967295
15:21:46.914 [main] INFO  c.b.b.starter.StandaloneStarter - Setting: DistLimitUnitInterval=0